### PR TITLE
Make CalcTimeShift() return time steps not months

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -50,21 +50,6 @@ SimInfo::SimInfo(int dur, int y0, int m0, std::string handle)
       seed(kDefaultSeed),
       stride(kDefaultStride) {}
 
-SimInfo::SimInfo(int dur, int y0, int m0, std::string handle, int timestep)
-    : duration(dur),
-      y0(y0),
-      m0(m0),
-      dt(timestep),
-      decay("manual"),
-      branch_time(-1),
-      handle(handle),
-      explicit_inventory(false),
-      explicit_inventory_compact(false),
-      parent_sim(boost::uuids::nil_uuid()),
-      parent_type("init"),
-      seed(kDefaultSeed),
-      stride(kDefaultStride) {}
-
 SimInfo::SimInfo(int dur, int y0, int m0, std::string handle, std::string d)
     : duration(dur),
       y0(y0),

--- a/src/context.cc
+++ b/src/context.cc
@@ -50,6 +50,21 @@ SimInfo::SimInfo(int dur, int y0, int m0, std::string handle)
       seed(kDefaultSeed),
       stride(kDefaultStride) {}
 
+SimInfo::SimInfo(int dur, int y0, int m0, std::string handle, int timestep)
+    : duration(dur),
+      y0(y0),
+      m0(m0),
+      dt(timestep),
+      decay("manual"),
+      branch_time(-1),
+      handle(handle),
+      explicit_inventory(false),
+      explicit_inventory_compact(false),
+      parent_sim(boost::uuids::nil_uuid()),
+      parent_type("init"),
+      seed(kDefaultSeed),
+      stride(kDefaultStride) {}
+
 SimInfo::SimInfo(int dur, int y0, int m0, std::string handle, std::string d)
     : duration(dur),
       y0(y0),

--- a/src/context.h
+++ b/src/context.h
@@ -62,6 +62,16 @@ class SimInfo {
   /// @return a SimInfo instance
   SimInfo(int dur, int y0 = 2010, int m0 = 1, std::string handle = "");
 
+  /// @brief constructs a SimInfo instance using some default variables
+  /// @param dur simulation duration in number of timesteps
+  /// @param y0 start year for the simulation
+  /// @param m0 start month for the simulation
+  /// @param handle is this simulation's unique simulation handle
+  /// @param timestep is the length of the timestep in seconds
+  /// @return a SimInfo instance
+  SimInfo(int dur, int y0, int m0, std::string handle, 
+          int timestep = kDefaultTimeStepDur);
+
   /// @brief constructs a SimInfo instance using no default variables
   /// @param dur simulation duration in number of timesteps
   /// @param y0 start year for the simulation

--- a/src/context.h
+++ b/src/context.h
@@ -26,6 +26,8 @@ const uint64_t cyclusYear = 31558200;
 
 const uint64_t kMonthsPerYear = 12;
 
+const uint64_t cyclusMonth = cyclusYear/kMonthsPerYear;
+
 const uint64_t kDefaultTimeStepDur = cyclusYear / kMonthsPerYear;
 
 const uint64_t kDefaultSeed = 20160212;

--- a/src/context.h
+++ b/src/context.h
@@ -26,9 +26,9 @@ const uint64_t cyclusYear = 31558200;
 
 const uint64_t kMonthsPerYear = 12;
 
-const uint64_t cyclusMonth = cyclusYear/kMonthsPerYear;
+const uint64_t cyclusMonth = cyclusYear / kMonthsPerYear;
 
-const uint64_t kDefaultTimeStepDur = cyclusYear / kMonthsPerYear;
+const uint64_t kDefaultTimeStepDur = cyclusMonth;
 
 const uint64_t kDefaultSeed = 20160212;
 
@@ -63,16 +63,6 @@ class SimInfo {
   /// @param handle is this simulation's unique simulation handle
   /// @return a SimInfo instance
   SimInfo(int dur, int y0 = 2010, int m0 = 1, std::string handle = "");
-
-  /// @brief constructs a SimInfo instance using some default variables
-  /// @param dur simulation duration in number of timesteps
-  /// @param y0 start year for the simulation
-  /// @param m0 start month for the simulation
-  /// @param handle is this simulation's unique simulation handle
-  /// @param timestep is the length of the timestep in seconds
-  /// @return a SimInfo instance
-  SimInfo(int dur, int y0, int m0, std::string handle, 
-          int timestep = kDefaultTimeStepDur);
 
   /// @brief constructs a SimInfo instance using no default variables
   /// @param dur simulation duration in number of timesteps

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -289,7 +289,7 @@ int Timer::CalcTimeDiff(int year, int month) {
   }
   
   if (month >= 0) {
-    timediff_ += (month - si_.m0) * cyclusYear / kMonthsPerYear;
+    timediff_ += (month - si_.m0) * cyclusMonth;
   }
 
   // Casting because ctx_->dt() is uint64_t and so negatives don't play nice

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -293,7 +293,7 @@ int Timer::CalcTimeDiff(int year, int month) {
   }
 
   // Casting because ctx_->dt() is uint64_t and so negatives don't play nice
-  return static_cast<int>(timediff_ / static_cast<int64_t>(ctx_->dt()));
+  return timediff_ / static_cast<int>(ctx_->dt());
 
 }
 

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -292,7 +292,8 @@ int Timer::CalcTimeDiff(int year, int month) {
     timediff_ += (month - si_.m0) * cyclusYear / kMonthsPerYear;
   }
 
-  return timediff_;
+  // Casting because ctx_->dt() is uint64_t and so negatives don't play nice
+  return static_cast<int>(timediff_ / static_cast<int64_t>(ctx_->dt()));
 
 }
 

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -285,11 +285,11 @@ int Timer::CalcTimeDiff(int year, int month) {
 
   int timediff_ = 0;
   if (year >= 0) {
-    timediff_ += (year - si_.y0) * kMonthsPerYear;
+    timediff_ += (year - si_.y0) * cyclusYear;
   }
   
   if (month >= 0) {
-    timediff_ += month - si_.m0;
+    timediff_ += (month - si_.m0) * cyclusYear / kMonthsPerYear;
   }
 
   return timediff_;

--- a/tests/timer_tests.cc
+++ b/tests/timer_tests.cc
@@ -156,21 +156,25 @@ TEST_P(TimerTestsFixture, TimeShiftTest) {
   // Create and initialize a new timer with a non-default timestep
   cyclus::Timer non_default_ti;
   cyclus::Context ctx2(&non_default_ti, &rec);
+  cyclus::SimInfo short_timestep(5);
+  short_timestep.dt = 1;
 
-  non_default_ti.Initialize(&ctx2, cyclus::SimInfo(5, 2010, 1, "", 1));
+  non_default_ti.Initialize(&ctx2, short_timestep);
 
   obs = non_default_ti.CalcTimeDiff(2010, 8);
-  exp = 7 * kDefaultTimeStepDur / ctx2.dt();
+  exp = 7 * cyclusMonth / ctx2.dt();
   EXPECT_EQ(exp, obs);
 
     // Create and initialize a new timer with a weird non-default timestep
   cyclus::Timer weird_non_default_ti;
   cyclus::Context ctx3(&weird_non_default_ti, &rec);
+  cyclus::SimInfo weird_timestep(5);
+  weird_timestep.dt = 13;
 
-  non_default_ti.Initialize(&ctx3, cyclus::SimInfo(5, 2010, 1, "", 13));
+  weird_non_default_ti.Initialize(&ctx3, weird_timestep);
 
-  obs = non_default_ti.CalcTimeDiff(2010, 8);
-  exp = 7 * kDefaultTimeStepDur / ctx3.dt();
+  obs = weird_non_default_ti.CalcTimeDiff(2010, 8);
+  exp = 7 * cyclusMonth / ctx3.dt();
   EXPECT_EQ(exp, obs);
 
 }

--- a/tests/timer_tests.cc
+++ b/tests/timer_tests.cc
@@ -129,27 +129,48 @@ TEST_P(TimerTestsFixture, TimeShiftTest) {
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2010, 2);
-  exp = 1 * kDefaultTimeStepDur;
+  exp = 1;
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2011,1);
-  exp = 12 * kDefaultTimeStepDur;
+  exp = 12;
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2011,5);
-  exp = 16 * kDefaultTimeStepDur;
+  exp = 16;
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2009,1);
-  exp = -12 * kDefaultTimeStepDur;
+  exp = -12;
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2009,11);
-  exp = -2 * kDefaultTimeStepDur;
+  exp = -2;
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2008,6);
-  exp = -19 * kDefaultTimeStepDur;
+  exp = -19;
+  EXPECT_EQ(exp, obs);
+
+
+  // Create and initialize a new timer with a non-default timestep
+  cyclus::Timer non_default_ti;
+  cyclus::Context ctx2(&non_default_ti, &rec);
+
+  non_default_ti.Initialize(&ctx2, cyclus::SimInfo(5, 2010, 1, "", 1));
+
+  obs = non_default_ti.CalcTimeDiff(2010, 8);
+  exp = 7 * kDefaultTimeStepDur / ctx2.dt();
+  EXPECT_EQ(exp, obs);
+
+    // Create and initialize a new timer with a weird non-default timestep
+  cyclus::Timer weird_non_default_ti;
+  cyclus::Context ctx3(&weird_non_default_ti, &rec);
+
+  non_default_ti.Initialize(&ctx3, cyclus::SimInfo(5, 2010, 1, "", 13));
+
+  obs = non_default_ti.CalcTimeDiff(2010, 8);
+  exp = 7 * kDefaultTimeStepDur / ctx3.dt();
   EXPECT_EQ(exp, obs);
 
 }

--- a/tests/timer_tests.cc
+++ b/tests/timer_tests.cc
@@ -129,27 +129,27 @@ TEST_P(TimerTestsFixture, TimeShiftTest) {
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2010, 2);
-  exp = 1;
+  exp = 1 * kDefaultTimeStepDur;
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2011,1);
-  exp = 12;
+  exp = 12 * kDefaultTimeStepDur;
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2011,5);
-  exp = 16;
+  exp = 16 * kDefaultTimeStepDur;
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2009,1);
-  exp = -12;
+  exp = -12 * kDefaultTimeStepDur;
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2009,11);
-  exp = -2;
+  exp = -2 * kDefaultTimeStepDur;
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2008,6);
-  exp = -19;
+  exp = -19 * kDefaultTimeStepDur;
   EXPECT_EQ(exp, obs);
 
 }


### PR DESCRIPTION
This one's pretty straightforward. Changes:

1. Added a new SimInfo constructor which can have a non-default timestep length (for use in testing)
2. Changed the CalcTimeShift() function to return time steps (note the weird casting because of cix_->dt() being uint64_t and not just regular int)
3. Added a few tests to make sure that weird time step lengths aren't going to mess things up

