### PR TITLE
Fix Failing Cycamore Unit Tests

### DIFF
--- a/.github/workflows/changelog_test.yml
+++ b/.github/workflows/changelog_test.yml
@@ -11,18 +11,11 @@ env:
 jobs:
   changelog_update:
     runs-on: ubuntu-latest
-    container:
-      image: alpine:3.14
 
     name: Is Changelog up-to-date ?
     steps:
-      - name: Install latest git
-        run: |
-          apk add --no-cache bash git openssh
-          git --version
-
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,7 @@ Since last release
 * Users can specify for random seed to be created for random number generation (#1950)
 
 **Changed:**
+* Absorb back to respect manual decay mode and the logic of the decay conditional (#1918)
 * Modified cycpp.py to fix a few whitespace-related bugs, and allow cyclus vars to be initialized (#1954)
 * Changed the epsilon (eps) in Material::Decay to 1e-4 allowing 1 day decay of tritium (#1946)
 * Changed the schema for recipes to require oneOrMore instead of zeroOrMore (#1940)

--- a/src/material.cc
+++ b/src/material.cc
@@ -104,24 +104,33 @@ Material::Ptr Material::ExtractComp(double qty, Composition::Ptr c,
 
 void Material::Absorb(Material::Ptr mat) {
 
-  // Handle absorb-specific decay rules
-  int common_decay_time;
-  if (HasContext() && mat->HasContext()) {
-    common_decay_time = ctx_->time();    
-  } else if (!HasContext() && !mat->HasContext() 
-              && mat->prev_decay_time_ > prev_decay_time_) {
-    throw ValueError("Cannot absorb a material that is more decayed than this one");
-  } else if (HasContext() != mat->HasContext()) {
-    throw cyclus::Error("Cannot combine a tracked and untracked material!");
-  } else {
-    common_decay_time = prev_decay_time_;
-  }
-  mat->Decay(common_decay_time);
-  this->Decay(common_decay_time);
+bool tracked = HasContext();
+bool mat_tracked = mat->HasContext();
 
-  // manually update decay time in case the change was so small
-  // that no decay was invoked
-  this->prev_decay_time_ = common_decay_time;
+if (tracked != mat_tracked) {
+  throw cyclus::Error("Cannot combine a tracked and untracked material!");
+}
+
+if (!tracked) {
+  if (mat->prev_decay_time_ > prev_decay_time_) {
+    throw ValueError(
+        "Cannot absorb a material that is more decayed than this one");
+  }
+
+  // Synchronize the incoming material with this material.
+  mat->Decay(prev_decay_time_);
+} else if (ctx_->sim_info().decay == "lazy") {
+  // NOTE: Absorb will only Decay materials like this if the decay mode is
+  // set to lazy. If more decay modes are introduced in the future which 
+  // want Absorb to decay, this will need to be changed
+  int common_decay_time = ctx_->time();
+
+  mat->Decay(common_decay_time);
+  Decay(common_decay_time);
+
+  // Decay may return early when the change is below its threshold.
+  prev_decay_time_ = common_decay_time;
+}
 
   // these calls force lazy evaluation if in lazy decay mode
   Composition::Ptr c0 = comp();

--- a/tests/material_tests.cc
+++ b/tests/material_tests.cc
@@ -454,6 +454,12 @@ TEST_F(MaterialTest, TransmutePrevDecay) {
 
 TEST_F(MaterialTest, AbsorbPrevDecay) {
   FakeContext* fake_ctx = new FakeContext(&ti, &rec);
+  
+  // FakeContexts get generated with "manual" decay by default,
+  // so we need to set it to lazy to get Absorb to decay.
+  SimInfo lazy_si(100, 2015, 1, "", "lazy");
+  fake_ctx->InitSim(lazy_si);
+
   TestFacility* fake_fac = new TestFacility(fake_ctx);
 
   double untracked_qty = 1.0;


### PR DESCRIPTION
This PR primarily does two things:

1. Absorb now respects manual decay (previously it would decay things whenever you absorbed if you were in manual mode, which was causing the failing unit test in Cycamore).
2. Updates the logical flow of the decay-on-Absorb conditions to make them easier to read/understand (I added another condition to one of the if statements and it became so unwieldy I asked Codex if there was a way to simplify/clarify the logic and I think it's a LOT better now).

I clean-built Cyclus and Cycamore-main and ran both sets of tests and everything passes now.